### PR TITLE
Added link to CKAD practice challenges on Katacoda.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 *   [CKAD Exercises](https://github.com/dgkanatsios/CKAD-exercises)
 *   [Kubernetes Hard Way](https://github.com/kelseyhightower/kubernetes-the-hard-way)
 *   [CKA Study Guide and Exercises](https://github.com/David-VTUK/CKA-StudyGuide)
+*   [CKAD Practice Questions](https://dev.to/liptanbiswas/ckad-practice-questions-4mpn)
 
 ## Tips
 


### PR DESCRIPTION
A set of practice challenges to prepare for the CNCF Certified Kubernetes Application Developer exam built using Katakoda in already provisioned and running Kubernetes cluster. Tests have verifications in place as well.

PS: They are authored by me.